### PR TITLE
Fix formatting in virtual sites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ rapid and significant changes.
 
 ## Commands
 
+* `pip install -r requirements.txt` - Install `mkdocs` and other necessary packages
 * `mkdocs serve` - Start the live-reloading docs server.
 * `mkdocs build` - Build the documentation site.

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -671,12 +671,16 @@ Standard usage is expected to rely primarily on the features documented above an
 
 We will implement experimental support for placement of off-atom (off-center) charges in a variety of contexts which may be chemically important in order to allow easy exploration of when these will be warranted.
 We will support the following different types or geometries of off-center charges (as diagrammed below):
+
 - `BondCharge`: This supports placement of a virtual site `S` along a vector between two specified atoms, e.g. to allow for a sigma hole for halogens or similar contexts. With positive values of the distance, the virtual site lies outside the first indexed atom (green in this image).
 ![Bond charge virtual site](figures/vsite_bondcharge.jpg)
+
 - `MonovalentLonePair`: This is originally intended for situations like a carbonyl, and allows placement of a virtual site `S` at a specified distance `d`, `inPlaneAngle` (theta 1 in the diagram), and `outOfPlaneAngle` (theta 2 in the diagram) relative to a central atom and two connected atoms.
 ![Monovalent lone pair virtual site](figures/vsite_monovalent.jpg)
+
 - `DivalentLonePair`: This is suitable for cases like four-point and five-point water models as well as pyrimidine; a charge site `S` lies a specified distance `d` from the central atom among three atoms (blue) along the bisector of the angle between the atoms (if `outOfPlaneAngle` is zero) or out of the plane by the specified angle (if `outOfPlaneAngle` is nonzero) with its projection along the bisector. For positive values fo the distance `d` the virtual site lies outside the 2-1-3 angle and for negative values it lies inside.
 ![Divalent lone pair virtual site](figures/vsite_divalent.jpg)
+
 - `TrivalentLonePair`: This is suitable for planar or tetrahedral nitrogen lone pairs; a charge site `S` lies above  the central atom (e.g. nitrogen, blue) a distance `d` along the vector perpendicular to the plane of the three connected atoms (2,3,4). With positive values of `d` the site lies above the nitrogen and with negative values it lies below the nitrogen.
 ![Trivalent lone pair virtual site](figures/vsite_trivalent.jpg)
 

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -673,15 +673,19 @@ We will implement experimental support for placement of off-atom (off-center) ch
 We will support the following different types or geometries of off-center charges (as diagrammed below):
 
 - `BondCharge`: This supports placement of a virtual site `S` along a vector between two specified atoms, e.g. to allow for a sigma hole for halogens or similar contexts. With positive values of the distance, the virtual site lies outside the first indexed atom (green in this image).
+
 ![Bond charge virtual site](figures/vsite_bondcharge.jpg)
 
 - `MonovalentLonePair`: This is originally intended for situations like a carbonyl, and allows placement of a virtual site `S` at a specified distance `d`, `inPlaneAngle` (theta 1 in the diagram), and `outOfPlaneAngle` (theta 2 in the diagram) relative to a central atom and two connected atoms.
+
 ![Monovalent lone pair virtual site](figures/vsite_monovalent.jpg)
 
 - `DivalentLonePair`: This is suitable for cases like four-point and five-point water models as well as pyrimidine; a charge site `S` lies a specified distance `d` from the central atom among three atoms (blue) along the bisector of the angle between the atoms (if `outOfPlaneAngle` is zero) or out of the plane by the specified angle (if `outOfPlaneAngle` is nonzero) with its projection along the bisector. For positive values fo the distance `d` the virtual site lies outside the 2-1-3 angle and for negative values it lies inside.
+
 ![Divalent lone pair virtual site](figures/vsite_divalent.jpg)
 
 - `TrivalentLonePair`: This is suitable for planar or tetrahedral nitrogen lone pairs; a charge site `S` lies above  the central atom (e.g. nitrogen, blue) a distance `d` along the vector perpendicular to the plane of the three connected atoms (2,3,4). With positive values of `d` the site lies above the nitrogen and with negative values it lies below the nitrogen.
+
 ![Trivalent lone pair virtual site](figures/vsite_trivalent.jpg)
 
 Each virtual site receives charge which is transferred from the desired atoms specified in the SMIRKS pattern via a `charge_increment#` parameter, e.g., if `charge_increment1=0.1*elementary_charge` then the virtual site will receive a charge of -0.1 and the atom labeled `1` will have its charge adjusted upwards by 0.1.


### PR DESCRIPTION
Some parts of the [virtual sites section](https://openforcefield.github.io/standards/standards/smirnoff/#virtualsites-virtual-sites-for-off-atom-charges) look a little funny to me:

![image](https://user-images.githubusercontent.com/7935382/152019809-a3fc38b1-26d4-466f-9e7c-f8699eb940aa.png)


This PR adds some newlines to fix the rendering. Here's some of what I see locally:

![image](https://user-images.githubusercontent.com/7935382/152019888-fe0b96f8-1900-4ff0-87f3-1a9e8037a4e6.png)
