### PR TITLE
Fix typos in virtual sites table

### DIFF
--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -721,7 +721,7 @@ In the SMIRNOFF format, these are encoded as:
 
 | VirtualSites section tag version   | Tag attributes and default values    | Required parameter attributes and default values   | Optional parameter attributes |
 |------------------------------------|--------------------------------------|----------------------------------------------------|-------------------------------|
-| 0.3                                | `exclusion_policy="parents"`         | `smirks`, `type`, `distance`, `charge_increment` (indexed), `inPlaneAngle` IF `type="MonovalentLonePair"`, `outOfPlaneAngle` IF `type="MonovalentLonePair` OR `type="DivalentLonePair"`,  `sigma=0.*angstrom`, `epsilon=0.*kilocalories_per_mole`, `name="EP"`, `match="all_permutations"` IF `type="BondCharge"` OR `type="MonovalentLonePair` OR `type="DivalentLonePair"`, `match="once"` IF `type="TrivalentLonePair` | N/A |
+| 0.3                                | `exclusion_policy="parents"`         | `smirks`, `type`, `distance`, `charge_increment` (indexed), `inPlaneAngle` IF `type="MonovalentLonePair"`, `outOfPlaneAngle` IF `type="MonovalentLonePair"` OR `type="DivalentLonePair"`,  `sigma=0.*angstrom`, `epsilon=0.*kilocalories_per_mole`, `name="EP"`, `match="all_permutations"` IF `type="BondCharge"` OR `type="MonovalentLonePair"` OR `type="DivalentLonePair"`, `match="once"` IF `type="TrivalentLonePair"` | N/A |
 
 
 ### Aromaticity models

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -721,7 +721,7 @@ In the SMIRNOFF format, these are encoded as:
 
 | VirtualSites section tag version   | Tag attributes and default values    | Required parameter attributes and default values   | Optional parameter attributes |
 |------------------------------------|--------------------------------------|----------------------------------------------------|-------------------------------|
-| 0.3                                | `exclusion_policy="parents"`         | `smirks`, `type`, `distance`, `charge_increment` (indexed), `inPlaneAngle` IF `type="MonovalentLonePair"`, `outOfPlaneAngle` IF `type="MonovalentLonePair` OR `type="DivalentLonePair"`,  `sigma=0.*angstrom`, `epsilon=0.*kilocalories_per_mole`, `name="EP"`, `match="all_permutations"` IF `type=BondCharge` OR `type="MonovalentLonePair` OR `type="DivalentLonePair"`, `match="once"` IF `type="TrivalentLonePair` | N/A |
+| 0.3                                | `exclusion_policy="parents"`         | `smirks`, `type`, `distance`, `charge_increment` (indexed), `inPlaneAngle` IF `type="MonovalentLonePair"`, `outOfPlaneAngle` IF `type="MonovalentLonePair` OR `type="DivalentLonePair"`,  `sigma=0.*angstrom`, `epsilon=0.*kilocalories_per_mole`, `name="EP"`, `match="all_permutations"` IF `type="BondCharge"` OR `type="MonovalentLonePair` OR `type="DivalentLonePair"`, `match="once"` IF `type="TrivalentLonePair` | N/A |
 
 
 ### Aromaticity models


### PR DESCRIPTION
I found some typesetting inconsistencies in the formatting in the [virtual sites table](https://openforcefield.github.io/standards/standards/smirnoff/#virtualsites-virtual-sites-for-off-atom-charges) that were mildly unsightly:

![image](https://user-images.githubusercontent.com/7935382/155817103-c00211cc-0643-4b8d-b29f-697384b18263.png)
