### PR TITLE
OFF-EP 0005b

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ rapid and significant changes.
 
 ## Commands
 
+* `pip install -r requirements.txt` - Install `mkdocs` and other necessary packages
 * `mkdocs serve` - Start the live-reloading docs server.
 * `mkdocs build` - Build the documentation site.

--- a/docs/enhancement-proposals/off-ep-0005.md
+++ b/docs/enhancement-proposals/off-ep-0005.md
@@ -44,7 +44,7 @@ To solve these issues, this OFF-EP proposes:
 * For reaction field or other methods, the `periodic_potential` can specify the exact functional form used for the periodic potential or a keyword denoting a common choice, along with the optional `cutoff` and `solvent_dielectric` attributes
 * The `nonperiodic_potential` attribute defaults to `Coulomb` indicating the Coulomb potential is to be used in non-periodic systems, though other functional forms are accepted.
 * The `exception_potential` attribute defaults to `Coulomb`, indicating the Coulomb potential is to be used for exceptions, though other functional forms are accepted.
-* We explicitly specify which self-consistent physical constants should be used to compute
+* We explicitly specify which self-consistent physical constants should be used.
 
 We leave these to future extensions:
 * We reserve the possibility of adding a `nonperiodic_potential` keyword at a future date should it become necessary to permit different choices for non-periodic systems

--- a/docs/enhancement-proposals/off-ep-0005.md
+++ b/docs/enhancement-proposals/off-ep-0005.md
@@ -1,0 +1,44 @@
+# OFF-EP 0005 — Allow different electrostatics methods to be used on period and non-periodic systems
+
+**Status:** Proposed
+
+**Authors:** Matt Thompson
+
+**Stakeholders:** Karmen Condic-Jurkic, Jeffrey Wagner, David Mobley, John Chodera
+
+**Acceptance criteria:** Unanimity
+
+**Created:** 2020-02-18
+
+**Discussion:** [Issue #29](https://github.com/openforcefield/standards/issues/29)
+
+**Implementation:** [``openff-standards``](https://github.com/openforcefield/openff-standards)
+
+## Abstract
+
+This change allows for the `<Electrostatics>` tag to optionally specify that different methods
+shouuld be used for periodic (i.e. condensed-phase) and non-periodic (i.e. gas phase) systems. This
+in particular enables a force field to specify that PME should be used for periodic systems and no
+cutoff should be used for non-periodic systems.
+
+## Motivation and Scope
+
+## Usage and Impact
+
+## Backward compatibility
+
+## Detailed description
+
+## Alternatives
+
+## Discussion
+
+- Toolkit [#1084](https://github.com/openforcefield/openff-toolkit/issues/1084)
+- Standards [#29](https://github.com/openforcefield/standards/issues/29)
+
+## Copyright
+
+This template is based upon the
+[OFF-EP template](https://openforcefield.github.io/standards/enhancement-proposals/off-ep-template/).
+
+This document is explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/docs/enhancement-proposals/off-ep-0005.md
+++ b/docs/enhancement-proposals/off-ep-0005.md
@@ -1,8 +1,8 @@
 # OFF-EP 0005 — Allow different electrostatics methods to be used on period and non-periodic systems
 
-**Status:** Proposed
+**Status:** Accepted
 
-**Authors:** Matt Thompson and John Chodera
+**Authors:** Matt Thompson and John Chodera, Jeffrey Wagner, Simon Boothroyd
 
 **Stakeholders:** Simon Boothroyd, Jeffrey Wagner, David Mobley, John Chodera
 
@@ -112,7 +112,7 @@ For `nonperiodic_potential`:
 
 For `exception_potential`:
 
-* `Coulomb` (default) denotes that the standard Coulomb potential should be used
+* `Coulomb` (default) denotes that the standard Coulomb potential should be used with no cutoff or reaction-field attenuation
 * A function denotes that the specified function should be used, which may make use of `cutoff`, `switch_width`, and/or `solvent_dielectric` terms
 
 ## Examples

--- a/docs/enhancement-proposals/off-ep-0005.md
+++ b/docs/enhancement-proposals/off-ep-0005.md
@@ -83,9 +83,13 @@ Concretely, the following conversions should be performed:
 | reaction-field | reaction-field             | Coulomb                     | Coulomb                   |
 | Coulomb        | Coulomb                    | Coulomb                     | Coulomb                   |
 
-The value of an 0.3 `Electrostatics` section's `cutoff` attribute should be propagated into the 0.4 `Electrostatics` sections `nonperiodic_cutoff` attribute.
+The value of an 0.3 `Electrostatics` section's `cutoff` attribute should be propagated into the 0.4 `Electrostatics` section's `nonperiodic_cutoff` attribute.
+
+The value of an 0.3 `Electrostatics` section's `switch_width` attribute should be propagated into the 0.4 `Electrostatics` section's `nonperiodic_switch_width` attribute.
 
 The value of the 0.4 `Electrostatics` section's `periodic_cutoff` should be set to `none`.
+
+The value of the 0.4 `Electrostatics` section's `periodic_switch_width` should be set to `none`.
 
 The value of the 0.4 `Electrostatics` section's `solvent_dielectric` should be set to `78.5`.
 
@@ -106,8 +110,10 @@ The `solvent_dielectric` tag attribute is added.
 
 The optional `nonperiodic_cutoff` tag attribute is intended to have the same meaning as the previous `cutoff` attribute, defaulting to `9.0*angstrom`. 
 
-The optional `periodic_cutoff` tag attribute is added to specify the cutoff used for `periodic_potential` if applicable, defaulting to `none`.
-Only `periodic_cutoff="none"` is allowed for Ewald methods---only finite-ranged methods should set this to a non-`none` value.
+The optional `nonperiodic_switch_width` tag attribute is intended to have the same meaning as the previous `switch_width` attribute, defaulting to `0*angstrom`.
+
+The optional `periodic_cutoff` and `periodic_switch_width` tag attributes are added to specify the cutoff and switching width used for `periodic_potential` if applicable, both defaulting to `none`.
+Only `periodic_cutoff="none"` and `periodic_switch_width="none"` is allowed for Ewald methods---only finite-ranged methods should set these to a non-`none` value.
 
 The optional `solvent_dielectric` tag attribute is added to specify the solvent dielectric used with finite-ranged potentials, defaulting to `78.5`.
 

--- a/docs/enhancement-proposals/off-ep-0005.md
+++ b/docs/enhancement-proposals/off-ep-0005.md
@@ -4,7 +4,7 @@
 
 **Authors:** Matt Thompson
 
-**Stakeholders:** Karmen Condic-Jurkic, Jeffrey Wagner, David Mobley, John Chodera
+**Stakeholders:** Simon Boothroyd, Jeffrey Wagner, David Mobley, John Chodera
 
 **Acceptance criteria:** Unanimity
 
@@ -17,7 +17,7 @@
 ## Abstract
 
 This change allows for the `<Electrostatics>` tag to optionally specify that different methods
-shouuld be used for periodic (i.e. condensed-phase) and non-periodic (i.e. gas phase) systems. This
+should be used for periodic (i.e. condensed-phase) and non-periodic (i.e. gas phase) systems. This
 in particular enables a force field to specify that PME should be used for periodic systems and no
 cutoff should be used for non-periodic systems.
 
@@ -81,7 +81,7 @@ content of the version 0.4 snippet represents what is it currently does.
 ## Detailed description
 
 The `method` tag attribute is **removed** and replaced with `method_periodic` and `method_nonperiodic`.
-The deault values of each are `"PME"` and `"Coulomb"`, respectively. The following section is added
+The default values of each are `"PME"` and `"Coulomb"`, respectively. The following section is added
 to justify and describe these new methods:
 
 ```
@@ -107,7 +107,7 @@ implemented in engines like GROMACS that do not support an equivalent of OpenMM'
 Resolving this incompatibility could be left to implementation, as it has been for years. This is not
 desirable as a general principle of maintaining specifications.
 
-This could be resolved by mandating that separaate force fields should be used for periodic and
+This could be resolved by mandating that separate force fields should be used for periodic and
 non-periodic systems. This would be a clunky user experience and should be avoided.
 
 ## Discussion

--- a/docs/enhancement-proposals/off-ep-0005.md
+++ b/docs/enhancement-proposals/off-ep-0005.md
@@ -23,11 +23,35 @@ cutoff should be used for non-periodic systems.
 
 ## Motivation and Scope
 
+In version 0.3 of the `<Electrostatics>` tag, the default and most commonly-used electrostatics
+method is PME (`method="PME")`. It is, however, not compatible with non-periodic systems, such as
+gas-phase and/or single-molecule systems. In practice, force fields defined with PME are modified by
+users in ways that make them compatible with non-periodic systems, such as the
+[``NoCutoff``](http://docs.openmm.org/latest/userguide/theory/02_standard_forces.html?highlight=nocutoff#coulomb-interaction-without-cutoff)
+option provided by OpenMM's ``NonbondedForce``.
+
+Given that is it not tractable to use (much less train) a force field that can only be applied to
+periodic OR non-periodic systems, this OFF-EP proposes that the `<Electrostatics>` tag may specify
+that different methods should be used for each kinda of systems.
+
+This OFF-EP
+* does not propose changes any detail of the `<vdW>` section
+* does not alter the intended meaning of `method="PME"`
+
 ## Usage and Impact
 
 ## Backward compatibility
 
 ## Detailed description
+
+TODO:
+* Copy or reference diff of specification
+* Decide if `method` should be removed / how to guess if `method` is specified but no others
+* Decide on removing `method="Coulomb"`
+  * Make sure there is wiggle room for engines that do not explicitly allow non-periodic simulation
+    but do allow for direct electrostatics with box size >> moleclue size (possibly with cut-off
+    electrostatics, but in a way that's effectively "no-cutoff")
+* Discuss how to upscale 0.3 to 0.4
 
 ## Alternatives
 

--- a/docs/enhancement-proposals/off-ep-0005.md
+++ b/docs/enhancement-proposals/off-ep-0005.md
@@ -32,10 +32,10 @@ option provided by OpenMM's ``NonbondedForce``.
 
 Given that is it not tractable to use (much less train) a force field that can only be applied to
 periodic OR non-periodic systems, this OFF-EP proposes that the `<Electrostatics>` tag may specify
-that different methods should be used for each kind of systems.
+that different methods should be used for each kind of system.
 
 This OFF-EP
-* does not propose changes any detail of the `<vdW>` section
+* does not propose changes in any detail of the `<vdW>` section
 * does not alter the intended meaning of `method="PME"`
 * does not add allowed methods for non-periodic systems (still only `Coulomb`), but does require
   explicitly specifying what is used for non-periodic systems
@@ -69,7 +69,7 @@ following tag header
 <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
 ```
 
-to the equivalent of reading
+to a less ambiguous header using version 0.4, which for this case could be
 
 ```
 <Electrostatics version="0.4" method_periodic="PME" method_nonperiodic="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>

--- a/docs/enhancement-proposals/off-ep-0005.md
+++ b/docs/enhancement-proposals/off-ep-0005.md
@@ -79,7 +79,7 @@ Concretely, the following conversions should be performed:
 |------------------|------------------------------|-------------------------------|-----------------------------|
 |  `PME`           | `Ewald3D-ConductingBoundary` | `Coulomb`                     | `Coulomb`                   |
 | `reaction-field` | `charge1*charge2/(4*pi*epsilon0)*(1/r + k_rf*r^2 - c_rf); k_rf=(cutoff^(-3))*(solvent_dielectric-1)/(2*solvent_dielectric+1); c_rf=cutoff^(-1)*(3*solvent_dielectric)/(2*solvent_dielectric+1)`             | `Coulomb`                     | `Coulomb`                   |
-|  `Coulomb`       | `Coulomb`                    | `Coulomb`                     | `Coulomb`                   |
+|  `Coulomb`       | `Ewald3D-ConductingBoundary` | `Coulomb`                     | `Coulomb`                   |
 
 If the 0.3 section's `method` does not actually involve the use of a `cutoff` or `switch_width` (such as is the case if `method="PME"`), those values may be set to their defaults in the 0.4 `Electrostatics` section.
 
@@ -101,7 +101,6 @@ The optional `solvent_dielectric` tag attribute is added to specify the solvent 
 For `periodic_potential`:
 
 * `Ewald3D-ConductingBoundary` (default) denotes that the Ewald potential with conducting (dielectric 0) boundary conditions are used
-* `Coulomb` denotes that the standard Coulomb potential should be used with specified cutoff `cutoff` and optionally switch width `switch_width`
 * A function denotes that the specified function should be used, which may make use of `cutoff`, `switch_width`, and/or `solvent_dielectric` terms
 * Future OFF-EPs may add specific keywords for common choices of reaction field electrostatics
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ stages of discussion or completion.
 * [OFF-EP 1 &mdash; Clarify that constraint distances override equilibrium bond distances](enhancement-proposals/off-ep-0001.md)
 
 ##### Open Proposals
+* [OFF-EP 5 &mdash; Resolve ambiguity over PME electrostatics for nonperiodic systems](enhancement-proposals/off-ep-0005.md)
 
 ##### Final Proposals
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,9 +27,9 @@ stages of discussion or completion.
 ##### Accepted Proposals
 
 * [OFF-EP 1 &mdash; Clarify that constraint distances override equilibrium bond distances](enhancement-proposals/off-ep-0001.md)
+* [OFF-EP 5 &mdash; Resolve ambiguity over PME electrostatics for nonperiodic systems](enhancement-proposals/off-ep-0005.md)
 
 ##### Open Proposals
-* [OFF-EP 5 &mdash; Resolve ambiguity over PME electrostatics for nonperiodic systems](enhancement-proposals/off-ep-0005.md)
 
 ##### Final Proposals
 

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -730,7 +730,7 @@ In the SMIRNOFF format, these are encoded as:
 
 | VirtualSites section tag version   | Tag attributes and default values    | Required parameter attributes and default values   | Optional parameter attributes |
 |------------------------------------|--------------------------------------|----------------------------------------------------|-------------------------------|
-| 0.3                                | `exclusion_policy="parents"`         | `smirks`, `type`, `distance`, `charge_increment` (indexed), `inPlaneAngle` IF `type="MonovalentLonePair"`, `outOfPlaneAngle` IF `type="MonovalentLonePair` OR `type="DivalentLonePair"`,  `sigma=0.*angstrom`, `epsilon=0.*kilocalories_per_mole`, `name="EP"`, `match="all_permutations"` IF `type=BondCharge` OR `type="MonovalentLonePair` OR `type="DivalentLonePair"`, `match="once"` IF `type="TrivalentLonePair` | N/A |
+| 0.3                                | `exclusion_policy="parents"`         | `smirks`, `type`, `distance`, `charge_increment` (indexed), `inPlaneAngle` IF `type="MonovalentLonePair"`, `outOfPlaneAngle` IF `type="MonovalentLonePair` OR `type="DivalentLonePair"`,  `sigma=0.*angstrom`, `epsilon=0.*kilocalories_per_mole`, `name="EP"`, `match="all_permutations"` IF `type="BondCharge"` OR `type="MonovalentLonePair` OR `type="DivalentLonePair"`, `match="once"` IF `type="TrivalentLonePair` | N/A |
 
 
 ### Aromaticity models

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -671,13 +671,21 @@ Standard usage is expected to rely primarily on the features documented above an
 
 We will implement experimental support for placement of off-atom (off-center) charges in a variety of contexts which may be chemically important in order to allow easy exploration of when these will be warranted.
 We will support the following different types or geometries of off-center charges (as diagrammed below):
+
 - `BondCharge`: This supports placement of a virtual site `S` along a vector between two specified atoms, e.g. to allow for a sigma hole for halogens or similar contexts. With positive values of the distance, the virtual site lies outside the first indexed atom (green in this image).
+
 ![Bond charge virtual site](figures/vsite_bondcharge.jpg)
+
 - `MonovalentLonePair`: This is originally intended for situations like a carbonyl, and allows placement of a virtual site `S` at a specified distance `d`, `inPlaneAngle` (theta 1 in the diagram), and `outOfPlaneAngle` (theta 2 in the diagram) relative to a central atom and two connected atoms.
+
 ![Monovalent lone pair virtual site](figures/vsite_monovalent.jpg)
+
 - `DivalentLonePair`: This is suitable for cases like four-point and five-point water models as well as pyrimidine; a charge site `S` lies a specified distance `d` from the central atom among three atoms (blue) along the bisector of the angle between the atoms (if `outOfPlaneAngle` is zero) or out of the plane by the specified angle (if `outOfPlaneAngle` is nonzero) with its projection along the bisector. For positive values fo the distance `d` the virtual site lies outside the 2-1-3 angle and for negative values it lies inside.
+
 ![Divalent lone pair virtual site](figures/vsite_divalent.jpg)
+
 - `TrivalentLonePair`: This is suitable for planar or tetrahedral nitrogen lone pairs; a charge site `S` lies above  the central atom (e.g. nitrogen, blue) a distance `d` along the vector perpendicular to the plane of the three connected atoms (2,3,4). With positive values of `d` the site lies above the nitrogen and with negative values it lies below the nitrogen.
+
 ![Trivalent lone pair virtual site](figures/vsite_trivalent.jpg)
 
 Each virtual site receives charge which is transferred from the desired atoms specified in the SMIRKS pattern via a `charge_increment#` parameter, e.g., if `charge_increment1=0.1*elementary_charge` then the virtual site will receive a charge of -0.1 and the atom labeled `1` will have its charge adjusted upwards by 0.1.

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -388,7 +388,7 @@ The `nonperiodic_potential` attribute specifies the manner in which electrostati
 
 The `exception_potential` attribute specifies the treatment of intramolecular electrostatics exceptions, such as scaled 1-4 interactions. Allowed values are:
 
-* `Coulomb` (default) denotes that the standard Coulomb potential should be used
+* `Coulomb` (default) denotes that the standard Coulomb potential should be used with no cutoff or reaction-field attenuation
 * A function denotes that the specified function should be used, which may make use of `cutoff`, `switch_width`, and/or `solvent_dielectric` terms
 
 The interaction scaling parameters applied to atoms connected by a few bonds are
@@ -400,7 +400,7 @@ The interaction scaling parameters applied to atoms connected by a few bonds are
 
 Currently, no child tags are used because the charge model is specified via different means (currently library charges or BCCs).
 
-For potentials where the cutoff determines the potential energy of the system (such as reaction field methods and `Coulomb`), the appropriate `cutoff` distance must also be specified, and the appropriate `switch_width` should be set to a numerical value if a switching function is to be used.
+For potentials where the cutoff determines the potential energy of the system (such as custom expression or reaction field methods), the appropriate `cutoff` distance must also be specified, and the appropriate `switch_width` should be set to a numerical value if a switching function is to be used.
 
 It is possible to define an Electrostatics section where no potential uses `cutoff`, `switch_width`, or `solvent_dielectric`. In these cases it is strongly recommended that these values be set to `none` to avoid ambiguity. 
 

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -104,6 +104,10 @@ The `<Date>` tag should conform to [ISO 8601 date formatting guidelines](https:/
 !!! todo
     Should we have a separate `<Metadata>` or `<Provenance>` section that users can add whatever they want to? This would minimize the potential for accidentally colliding with other tags we add in the future.
 
+### Physical constants
+
+All published SMIRNOFF specification versions are intended for use with CODATA 2018 physical constants.  
+
 ### Parameter generators
 
 Within the `<SMIRNOFF>` tag, top-level tags encode parameters for a force field based on a SMARTS/SMIRKS-based specification describing the chemical environment the parameters are to be applied to.
@@ -364,21 +368,29 @@ Later revisions will also provide support for special interactions using the `<A
 
 Electrostatic interactions are specified via the `<Electrostatics>` tag.
 ```XML
-<Electrostatics version="0.4" method_periodic="PME" method_nonperiodic="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
+<Electrostatics version="0.4" periodic_potential="PME" nonperiodic_potential="Coulomb" exception_potential="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
 ```
 
 Some methods for computing electrostatic interactions are not valid for periodic systems, so
-separate methods must be specified for periodic (`method_periodic`) and non-periodic
-(`method_nonperiodic`) systems.
+separate methods must be specified for periodic (`periodic_potential`) and non-periodic
+(`nonperiodic_potential`) systems.
 
-The `method_periodic` attribute specifies the manner in which electrostatic interactions are to be computed in periodic systems. Allowed values are:
+The `periodic_potential` attribute specifies the manner in which electrostatic interactions are to be computed in periodic systems. Allowed values are:
 
-* `PME` - [particle mesh Ewald](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-particle-mesh-ewald) should be used (DEFAULT); can only apply to periodic systems
-* `reaction-field` - [reaction-field electrostatics](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-cutoff) should be used; can only apply to periodic systems
+* `PME` - [particle mesh Ewald](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-particle-mesh-ewald) should be used (DEFAULT)
+* `reaction-field` - [reaction-field electrostatics](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-cutoff) should be used
+* `Coulomb` denotes that the standard Coulomb potential should be used with specified cutoff `periodic_cutoff`
+* A function denotes that the specified function should be used with specified cutoff `periodic_cutoff` and optionally `solvent_dielectric`
 
-The `method_nonperiodic` attribute specifies the manner in which electrostatic interactions are to be computed in non-periodic systems. Allowed values are:
-* `Coulomb` - direct electrostatic interactions should be used without reaction-field attenuation and
-  no cut-off (or with a cutoff that is larger than any interaction distance).
+The `nonperiodic_potential` attribute specifies the manner in which electrostatic interactions are to be computed in non-periodic systems. Allowed values are:
+
+* `Coulomb` denotes that the standard Coulomb potential should be used (without reaction field attenuation) with optional specified cutoff `nonperiodic_cutoff`
+* A function denotes that the specified function should be used with optional specified cutoff `nonperiodic_cutoff` and optionally `solvent_dielectric`
+
+The `exception_potential` attribute specifies the treatment of intramolecular electrostatics exceptions, such as scaled 1-4 interactions. Allowed values are:
+
+* `Coulomb` denotes that the standard Coulomb potential should be used with no cutoff
+* A function denotes that the specified function should be used with no cutoff and optionally `solvent_dielectric`
 
 The interaction scaling parameters applied to atoms connected by a few bonds are
 
@@ -389,12 +401,12 @@ The interaction scaling parameters applied to atoms connected by a few bonds are
 
 Currently, no child tags are used because the charge model is specified via different means (currently library charges or BCCs).
 
-For methods where the cutoff is not simply an implementation detail but determines the potential energy of the system (`reaction-field` and `Coulomb`), the `cutoff` distance must also be specified, and a `switch_width` if a switching function is to be used.
+For methods where the cutoff is not simply an implementation detail but determines the potential energy of the system (such as `reaction-field` and `Coulomb`), the appropriate `cutoff` distance must also be specified, and a `switch_width` if a switching function is to be used.
 
 | Electrostatics section tag version | Tag attributes and default values                                                                                                         | Required parameter attributes | Optional parameter attributes |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-------------------------------|
 | 0.3                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method="PME"`  | N/A                           | N/A                           |
-| 0.4                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method_periodic="PME"`, `method_nonperiodic="Coulomb"`  | N/A                           | N/A                           |
+| 0.4                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `periodic_cutoff="none"`, `nonperiodic_cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `periodic_potential="PME"`, `nonperiodic_potential="Coulomb"`, `exception_potential="Coulomb"`, `solvent_dielectric="78.5"`   | N/A                           | N/A                           |
 
 
 ### `<Bonds>`

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -401,12 +401,12 @@ The interaction scaling parameters applied to atoms connected by a few bonds are
 
 Currently, no child tags are used because the charge model is specified via different means (currently library charges or BCCs).
 
-For methods where the cutoff is not simply an implementation detail but determines the potential energy of the system (such as `reaction-field` and `Coulomb`), the appropriate `cutoff` distance must also be specified, and a `switch_width` if a switching function is to be used.
+For methods where the cutoff is not simply an implementation detail but determines the potential energy of the system (such as `reaction-field` and `Coulomb`), the appropriate `cutoff` distance must also be specified, and the appropriate `switch_width` should be set to a numerical value if a switching function is to be used.
 
 | Electrostatics section tag version | Tag attributes and default values                                                                                                         | Required parameter attributes | Optional parameter attributes |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-------------------------------|
 | 0.3                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method="PME"`  | N/A                           | N/A                           |
-| 0.4                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `periodic_cutoff="none"`, `nonperiodic_cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `periodic_potential="PME"`, `nonperiodic_potential="Coulomb"`, `exception_potential="Coulomb"`, `solvent_dielectric="78.5"`   | N/A                           | N/A                           |
+| 0.4                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `periodic_cutoff="none"`, `nonperiodic_cutoff="9.0*angstrom"`, `periodic_switch_width="none"`, `nonperiodic_switch_width="0*angstrom"`, `periodic_potential="PME"`, `nonperiodic_potential="Coulomb"`, `exception_potential="Coulomb"`, `solvent_dielectric="78.5"`   | N/A                           | N/A                           |
 
 
 ### `<Bonds>`

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -378,7 +378,6 @@ separate methods must be specified for periodic (`periodic_potential`) and non-p
 The `periodic_potential` attribute specifies the manner in which electrostatic interactions are to be computed in periodic systems. Allowed values are:
 
 * `Ewald3D-ConductingBoundary` (default) denotes that a method like [particle mesh Ewald](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-particle-mesh-ewald) should be used
-* `Coulomb` denotes that the standard Coulomb potential should be used with specified cutoff `cutoff` and optionally switch width `switch_width`
 * A function denotes that the specified function should be used, which may make use of `cutoff`, `switch_width`, and/or `solvent_dielectric` terms
 
 The `nonperiodic_potential` attribute specifies the manner in which electrostatic interactions are to be computed in non-periodic systems. Allowed values are:

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -364,10 +364,10 @@ Later revisions will also provide support for special interactions using the `<A
 
 Electrostatic interactions are specified via the `<Electrostatics>` tag.
 ```XML
-<Electrostatics version="0.3" method_periodic="PME" method_nonperiodic="no-cutoff" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
+<Electrostatics version="0.4" method_periodic="PME" method_nonperiodic="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
 ```
 
-Because some methods for computing electrostatics interactions are not valid for periodic systems,
+Some methods for computing electrostatics interactions are not valid for periodic systems, so
 separate methods must be specified for periodic (`method_periodic`) and non-periodic
 (`method_nonperiodic`) systems.
 
@@ -375,10 +375,9 @@ The `method_periodic` attribute specifies the manner in which electrostatic inte
 
 * `PME` - [particle mesh Ewald](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-particle-mesh-ewald) should be used (DEFAULT); can only apply to periodic systems
 * `reaction-field` - [reaction-field electrostatics](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-cutoff) should be used; can only apply to periodic systems
-* `Coulomb` - direct Coulomb interactions (with no reaction-field attenuation) should be used
 
 The `method_nonperiodic` attribute specifies the manner in which electrostatic interactions are to be computed to non-periodic systems. Allowed values are:
-* `no-cutoff` - electrostatics interactions should be used without reaction-field attenuation and
+* `Coulomb` - direct electrostatics interactions should be used without reaction-field attenuation and
   no cut-off (or with a cutoff that is larger than any intermolecular distance).
 
 The interaction scaling parameters applied to atoms connected by a few bonds are
@@ -395,7 +394,7 @@ For methods where the cutoff is not simply an implementation detail but determin
 | Electrostatics section tag version | Tag attributes and default values                                                                                                         | Required parameter attributes | Optional parameter attributes |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-------------------------------|
 | 0.3                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method="PME"`  | N/A                           | N/A                           |
-| 0.4                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method_periodic="PME"`, `method_nonperiodic="no-cutoff"`  | N/A                           | N/A                           |
+| 0.4                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method_periodic="PME"`, `method_nonperiodic="Coulomb"`  | N/A                           | N/A                           |
 
 
 ### `<Bonds>`

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -402,7 +402,7 @@ Currently, no child tags are used because the charge model is specified via diff
 
 For potentials where the cutoff determines the potential energy of the system (such as reaction field methods and `Coulomb`), the appropriate `cutoff` distance must also be specified, and the appropriate `switch_width` should be set to a numerical value if a switching function is to be used.
 
-For potentials which do not make use of a `cutoff`, `switch_width`, or `solvent_dielectric`, these values will not be used (and it is strongly recommended that they be set to `none` to avoid ambiguity.) 
+It is possible to define an Electrostatics section where no potential uses `cutoff`, `switch_width`, or `solvent_dielectric`. In these cases it is strongly recommended that these values be set to `none` to avoid ambiguity. 
 
 | Electrostatics section tag version | Tag attributes and default values                                                                                                         | Required parameter attributes | Optional parameter attributes |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-------------------------------|

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -402,7 +402,7 @@ Currently, no child tags are used because the charge model is specified via diff
 
 For potentials where the cutoff determines the potential energy of the system (such as reaction field methods and `Coulomb`), the appropriate `cutoff` distance must also be specified, and the appropriate `switch_width` should be set to a numerical value if a switching function is to be used.
 
-For potentials which do not make use of a `cutoff` or `switch_width`, these values will not be used (and it is strongly recommended that they be set to `none` to avoid ambiguity.) 
+For potentials which do not make use of a `cutoff`, `switch_width`, or `solvent_dielectric`, these values will not be used (and it is strongly recommended that they be set to `none` to avoid ambiguity.) 
 
 | Electrostatics section tag version | Tag attributes and default values                                                                                                         | Required parameter attributes | Optional parameter attributes |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-------------------------------|

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -364,13 +364,22 @@ Later revisions will also provide support for special interactions using the `<A
 
 Electrostatic interactions are specified via the `<Electrostatics>` tag.
 ```XML
-<Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
+<Electrostatics version="0.3" method_periodic="PME" method_nonperiodic="no-cutoff" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
 ```
-The `method` attribute specifies the manner in which electrostatic interactions are to be computed:
+
+Because some methods for computing electrostatics interactions are not valid for periodic systems,
+separate methods must be specified for periodic (`method_periodic`) and non-periodic
+(`method_nonperiodic`) systems.
+
+The `method_periodic` attribute specifies the manner in which electrostatic interactions are to be computed to periodic systems. Allowed values are:
 
 * `PME` - [particle mesh Ewald](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-particle-mesh-ewald) should be used (DEFAULT); can only apply to periodic systems
 * `reaction-field` - [reaction-field electrostatics](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-cutoff) should be used; can only apply to periodic systems
 * `Coulomb` - direct Coulomb interactions (with no reaction-field attenuation) should be used
+
+The `method_nonperiodic` attribute specifies the manner in which electrostatic interactions are to be computed to non-periodic systems. Allowed values are:
+* `no-cutoff` - electrostatics interactions should be used without reaction-field attenuation and
+  no cut-off (or with a cutoff that is larger than any intermolecular distance).
 
 The interaction scaling parameters applied to atoms connected by a few bonds are
 
@@ -386,6 +395,7 @@ For methods where the cutoff is not simply an implementation detail but determin
 | Electrostatics section tag version | Tag attributes and default values                                                                                                         | Required parameter attributes | Optional parameter attributes |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-------------------------------|
 | 0.3                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method="PME"`  | N/A                           | N/A                           |
+| 0.4                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method_periodic="PME"`, `method_nonperiodic="no-cutoff"`  | N/A                           | N/A                           |
 
 
 ### `<Bonds>`

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -367,18 +367,18 @@ Electrostatic interactions are specified via the `<Electrostatics>` tag.
 <Electrostatics version="0.4" method_periodic="PME" method_nonperiodic="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
 ```
 
-Some methods for computing electrostatics interactions are not valid for periodic systems, so
+Some methods for computing electrostatic interactions are not valid for periodic systems, so
 separate methods must be specified for periodic (`method_periodic`) and non-periodic
 (`method_nonperiodic`) systems.
 
-The `method_periodic` attribute specifies the manner in which electrostatic interactions are to be computed to periodic systems. Allowed values are:
+The `method_periodic` attribute specifies the manner in which electrostatic interactions are to be computed in periodic systems. Allowed values are:
 
 * `PME` - [particle mesh Ewald](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-particle-mesh-ewald) should be used (DEFAULT); can only apply to periodic systems
 * `reaction-field` - [reaction-field electrostatics](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-cutoff) should be used; can only apply to periodic systems
 
-The `method_nonperiodic` attribute specifies the manner in which electrostatic interactions are to be computed to non-periodic systems. Allowed values are:
-* `Coulomb` - direct electrostatics interactions should be used without reaction-field attenuation and
-  no cut-off (or with a cutoff that is larger than any intermolecular distance).
+The `method_nonperiodic` attribute specifies the manner in which electrostatic interactions are to be computed in non-periodic systems. Allowed values are:
+* `Coulomb` - direct electrostatic interactions should be used without reaction-field attenuation and
+  no cut-off (or with a cutoff that is larger than any interaction distance).
 
 The interaction scaling parameters applied to atoms connected by a few bonds are
 

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -368,7 +368,7 @@ Later revisions will also provide support for special interactions using the `<A
 
 Electrostatic interactions are specified via the `<Electrostatics>` tag.
 ```XML
-<Electrostatics version="0.4" periodic_potential="PME" nonperiodic_potential="Coulomb" exception_potential="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
+<Electrostatics version="0.4" periodic_potential="Ewald3D-ConductingBoundary" nonperiodic_potential="Coulomb" exception_potential="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0"/>
 ```
 
 Some methods for computing electrostatic interactions are not valid for periodic systems, so
@@ -377,20 +377,19 @@ separate methods must be specified for periodic (`periodic_potential`) and non-p
 
 The `periodic_potential` attribute specifies the manner in which electrostatic interactions are to be computed in periodic systems. Allowed values are:
 
-* `PME` - [particle mesh Ewald](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-particle-mesh-ewald) should be used (DEFAULT)
-* `reaction-field` - [reaction-field electrostatics](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-cutoff) should be used
-* `Coulomb` denotes that the standard Coulomb potential should be used with specified cutoff `periodic_cutoff`
-* A function denotes that the specified function should be used with specified cutoff `periodic_cutoff` and optionally `solvent_dielectric`
+* `Ewald3D-ConductingBoundary` (default) denotes that a method like [particle mesh Ewald](https://docs.openmm.org/latest/userguide/theory.html#coulomb-interaction-with-particle-mesh-ewald) should be used
+* `Coulomb` denotes that the standard Coulomb potential should be used with specified cutoff `cutoff` and optionally switch width `switch_width`
+* A function denotes that the specified function should be used, which may make use of `cutoff`, `switch_width`, and/or `solvent_dielectric` terms
 
 The `nonperiodic_potential` attribute specifies the manner in which electrostatic interactions are to be computed in non-periodic systems. Allowed values are:
 
-* `Coulomb` denotes that the standard Coulomb potential should be used (without reaction field attenuation) with optional specified cutoff `nonperiodic_cutoff`
-* A function denotes that the specified function should be used with optional specified cutoff `nonperiodic_cutoff` and optionally `solvent_dielectric`
+* `Coulomb` (default) denotes that the standard Coulomb potential should be used with no cutoff or reaction-field attenuation
+* A function denotes that the specified function should be used, which may make use of `cutoff`, `switch_width`, and/or `solvent_dielectric` terms
 
 The `exception_potential` attribute specifies the treatment of intramolecular electrostatics exceptions, such as scaled 1-4 interactions. Allowed values are:
 
-* `Coulomb` denotes that the standard Coulomb potential should be used with no cutoff
-* A function denotes that the specified function should be used with no cutoff and optionally `solvent_dielectric`
+* `Coulomb` (default) denotes that the standard Coulomb potential should be used
+* A function denotes that the specified function should be used, which may make use of `cutoff`, `switch_width`, and/or `solvent_dielectric` terms
 
 The interaction scaling parameters applied to atoms connected by a few bonds are
 
@@ -401,12 +400,14 @@ The interaction scaling parameters applied to atoms connected by a few bonds are
 
 Currently, no child tags are used because the charge model is specified via different means (currently library charges or BCCs).
 
-For methods where the cutoff is not simply an implementation detail but determines the potential energy of the system (such as `reaction-field` and `Coulomb`), the appropriate `cutoff` distance must also be specified, and the appropriate `switch_width` should be set to a numerical value if a switching function is to be used.
+For potentials where the cutoff determines the potential energy of the system (such as reaction field methods and `Coulomb`), the appropriate `cutoff` distance must also be specified, and the appropriate `switch_width` should be set to a numerical value if a switching function is to be used.
+
+For potentials which do not make use of a `cutoff` or `switch_width`, these values will not be used (and it is strongly recommended that they be set to `none` to avoid ambiguity.) 
 
 | Electrostatics section tag version | Tag attributes and default values                                                                                                         | Required parameter attributes | Optional parameter attributes |
 |------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-------------------------------|
-| 0.3                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method="PME"`  | N/A                           | N/A                           |
-| 0.4                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `periodic_cutoff="none"`, `nonperiodic_cutoff="9.0*angstrom"`, `periodic_switch_width="none"`, `nonperiodic_switch_width="0*angstrom"`, `periodic_potential="PME"`, `nonperiodic_potential="Coulomb"`, `exception_potential="Coulomb"`, `solvent_dielectric="78.5"`   | N/A                           | N/A                           |
+| 0.3                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="9.0*angstrom"`, `switch_width="0*angstrom"`, `method="PME"` | N/A                           | N/A                           |
+| 0.4                                | `scale12="0"`, `scale13="0"`, `scale14="0.833333"`, `scale15="1.0"`, `cutoff="none"`, `switch_width="none"`, `periodic_potential="Ewald3D-ConductingBoundary"`, `nonperiodic_potential="Coulomb"`, `exception_potential="Coulomb"`, `solvent_dielectric="none"`   | N/A                           | N/A                           |
 
 
 ### `<Bonds>`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,8 @@ nav:
     - 'OFF-EP 0 - Purpose and Process': 'enhancement-proposals/off-ep-0000.md'
     - 'OFF-EP X - Template': 'enhancement-proposals/off-ep-template.md'
     - 'OFF-EP 1 - Clarify that constraint distances override equilibrium bond distances': 'enhancement-proposals/off-ep-0001.md'
+    - 'OFF-EP 5 - Resolve ambiguity over PME electrostatics for nonperiodic systems': 'enhancement-proposals/off-ep-0005.md'
+
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
An alternative proposal to #30 to fix #29.

Other modifications that may be possible:
* We could use `solvent_dielectric` to specify both reaction field dielectric constants and the Ewald boundary conditions dielectric constant (currently specified as part of the verbose `Ewald3D-ConductingBoundary` keyword)
* We could migrate the specification of [CODATA 2018](https://physics.nist.gov/cuu/Constants/index.html) physical constants to a higher-level attribute
* We could streamline or specify which physical constants are available in the potential expressions (here, `pi` and `epsilon0` are used)
* We could specify some common reaction field models (such as the [OpenMM reaction field model used in SireMol](http://docs.openmm.org/7.6.0/userguide/theory/02_standard_forces.html#coulomb-interaction-with-cutoff)) in this OFF-EP rather than relying on users to provide the complete functional form