### PR TITLE
Add OFF-EP 6 and update SMIRNOFF specification

### DIFF
--- a/docs/enhancement-proposals/off-ep-0006.md
+++ b/docs/enhancement-proposals/off-ep-0006.md
@@ -1,0 +1,84 @@
+# OFF-EP 6 — Define virtual site exclusion policy
+
+**Status:** Proposed
+
+**Authors:** Simon Boothroyd, simon.boothroyd@openforcefield.org
+
+**Stakeholders:** David Mobley, John Chodera, Jeffrey Wagner, Simon Boothroyd
+
+**Acceptance criteria:** Majority
+
+**Created:** 2022-04-05
+
+**Discussion:** [PR #35](https://github.com/openforcefield/standards/pull/35)
+
+**Implementation:** [PR #35](https://github.com/openforcefield/standards/pull/35)
+
+## Abstract
+
+This OFF-EP aims to [define the allowed virtual site exclusion policies](#detailed-description), which are currently
+only listed without definition.
+
+## Motivation and Scope
+
+The virtual site section of the SMIRNOFF specification states that the top level `<VirtualSites>`parameter handler 
+allows an `exclusion_policy` to be defined, and the corresponding allowed values table (currently version 0.3) states 
+that the only allowed value is `parents`. The section does not however define what this means, nor does it address how 
+virtual site interactions are influenced by 1-N scale factors.
+
+## Usage and Impact
+
+Usage of virtual sites is understood to be currently limited to internal users on the OpenFF scientific team, and 
+mostly only limited to TIP4P water which should likely not need exclusions. As such, the impact of changing 
+the definition of the exclusion policy, even to one that doesn't necessarily agree with the current reference 
+implementation in the OpenFF toolkit, should be minimal to none.
+
+## Backward compatibility
+
+The [proposed definition](#detailed-description) conflicts with the OpenFF Toolkit reference implementation of the 
+`parents` exclusion policy, that currently assumes:
+
+> the user would want to exclude all non-bonded interactions between the virtual site and each 'parent atom' used to 
+  define the virtual sites' orientation and does no interaction scaling using, for example, the vdW or electrostatics 
+  `scale14` factor.
+
+This would mean that new versions of the reference implementation would yield different energies for molecules that
+contain greater than three atoms, and hence not be backwards compatible.
+
+To retain previous behaviour we could in principle incorporate the proposed definition as a new allowed exclusion 
+policy, `'inherit'`, however given the low (to zero) number of users this change would affect it is unclear that it
+is worth the extra maintenance burden, and is likely an acceptable break.
+
+## Detailed description
+
+This OFF-EP proposes defining the `parents` virtual site exclusion policy to mean:
+
+> virtual site particles should exclude non-bonded interactions with, or scale their interactions with, the same atoms 
+> as the main 'parent atom' that they are attached to does. Which atom is the 'parent atom' depends on the type of
+> virtual site: for `BondCharge`, `MonovalentLonePair`, `DivalentLonePair`, and `TrivalentLonePair` types, it is the 
+> atom labelled `:1` in the SMIRKS pattern.
+>
+> As an example, if the parent atom is separated by two bonds from another atom i.e a 1-3 pair, the virtual sites'
+> interaction with that other atom should also be treated as a 1-3 pair. Similarly, if the parent atom is separated by 
+> three bonds from another atom i.e a 1-4 pair, the virtual sites' interaction with that other atom should also be 
+> treated as a 1-4 pair and the interaction should be scaled by the appropriate `scale14` factor. 
+
+## Alternatives
+
+* Implement the proposed definition as a new allowed value as described in the [backward compatibility](#backward-compatibility) 
+  section. As mentioned however, it is not clear that the current `parents` implementation is broadly used, nor does it 
+  take into account important settings such as 1-4 scaling factors, and hence it is likely justified to just overwrite
+  the reference.
+
+## Discussion
+
+This preferred exclusion policy has been discussed by [external collaborators previously](https://github.com/openmm/openmm/issues/2045),
+who have also settled on the same definition as is proposed here.
+
+## Copyright
+
+*This template is based upon the [``numpy`` NEP template](
+https://github.com/numpy/numpy/blob/master/doc/neps/nep-template.rst) and the
+[``conda-forge`` CFEP template.](https://github.com/conda-forge/cfep/blob/master/cfep-00.md)*
+
+*All OFF-EPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).*

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,8 @@ stages of discussion or completion.
 
 ##### Open Proposals
 
+* [OFF-EP 6 &mdash; Define virtual site exclusion policy](enhancement-proposals/off-ep-0006.md)
+
 ##### Final Proposals
 
 ##### Rejected Proposals

--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -693,6 +693,18 @@ N may index any indexed atom.
 Additionally, each virtual site can bear Lennard-Jones parameters, specified by `sigma` and `epsilon` or `rmin_half` and `epsilon`.
 If unspecified these default to zero.
 
+Interactions between a virtual site and the other atoms / virtual sites in the molecule are controlled by the `exclusion_policy` parameter that can take values of:
+
+* `parent` - virtual site particles should exclude non-bonded interactions with, or scale their interactions with, the 
+  same particles that the main 'parent atom' that they are attached to does. Which atom is the 'parent atom' depends on 
+  the type of virtual site: for `BondCharge`, `MonovalentLonePair`, `DivalentLonePair`, and `TrivalentLonePair` types, 
+  it is the atom labelled `:1` in the SMIRKS pattern.
+
+  As an example, if the parent atom is separated by two bonds from another atom i.e a 1-3 pair, the virtual sites'
+  interaction with that other atom should also be treated as a 1-3 pair. Similarly, if the parent atom is separated by 
+  three bonds from another atom i.e a 1-4 pair, the virtual sites' interaction with that other atom should also be 
+  treated as a 1-4 pair and the interaction should be scaled by the appropriate `scale14` factor. 
+
 In the SMIRNOFF format, these are encoded as:
 ```XML
 <VirtualSites version="0.3" exclusion_policy="parents">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - 'OFF-EP 0 - Purpose and Process': 'enhancement-proposals/off-ep-0000.md'
     - 'OFF-EP X - Template': 'enhancement-proposals/off-ep-template.md'
     - 'OFF-EP 1 - Clarify that constraint distances override equilibrium bond distances': 'enhancement-proposals/off-ep-0001.md'
+    - 'OFF-EP 6 - Define virtual site exclusion policy': 'enhancement-proposals/off-ep-0006.md'
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
# Description

This OFF-EP aims to define the allowed virtual site exclusion policies, which are currently
only listed without definition.

@j-wags @davidlmobley @jchodera if you could please review ASAP, and if possible by the end of the week, it would be much appreciated.

