### PR TITLE
Fix rendering in constraints section

### DIFF
--- a/docs/standards/smirnoff.md
+++ b/docs/standards/smirnoff.md
@@ -659,6 +659,7 @@ To specify the constraint distance, or constrain two atoms that are not directly
   <!-- constrain water H...H, calculating equilibrium length from H-O-H equilibrium angle and H-O equilibrium bond lengths -->
   <Constraint smirks="[#1:1]-[#8X2H2]-[#1:2]" distance="1.8532*angstrom"/>
 </Constraints>
+```
 
 If a constraint is applied across a bond between two atoms, then the length of that bond will be constrained to:
 
@@ -667,7 +668,6 @@ If a constraint is applied across a bond between two atoms, then the length of t
 
 If the `<Constraint/>` parameter does not specify a distance and is applied to two atoms that either aren't bonded or which do not have an associated `<Bond/>` parameter, an exception should be raised.
 
-```
 Typical molecular simulation practice is to constrain all bonds to hydrogen to their equilibrium bond lengths and enforce rigid TIP3P geometry on water molecules:
 ```XML
 <Constraints version="0.3">


### PR DESCRIPTION
I found a misplaced triple-backticks that caused a rendering issue in the constraints section:

![image](https://user-images.githubusercontent.com/7935382/171679783-aa971a99-d934-4acd-aec9-7801c050aae1.png)

I'll double-check the rendering with this change but will merge without review.